### PR TITLE
feat(Carousel): done

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -12,3 +12,34 @@
   font-size: 28px;
   font-weight: 400;
 }
+
+.carousel-item.example {
+  display: flex;
+  align-items: center;
+  flex-flow: column nowrap;
+  color: #303030;
+  background-size: cover;
+  background-position: center bottom;
+  background-repeat: no-repeat;
+}
+
+.carousel-item.example .title {
+  margin-top: 10%;
+}
+
+.carousel-item.example .description {
+  margin-top: 0.5em;
+}
+
+.carousel-item.example.xphone {
+  color: white;
+  background-image: url("./assets/iphone.png");
+}
+
+.carousel-item.example.tablet {
+  background-image: url("./assets/tablet.png");
+}
+
+.carousel-item.example.airpods {
+  background-image: url("./assets/airpods.png");
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,25 @@
-import React from "react";
-import "./App.css";
+import React from 'react';
+import './App.css';
+import { Carousel, CarouselItem } from './components/carousel';
 
 function App() {
-  return <div className="App">{/* write your component here */}</div>;
+  return (
+    <div className="App">
+      <Carousel>
+        <CarouselItem className={'example xphone'}>
+          <div className={'title'}>xPhone</div>
+          <div className={'description'}>Lots to love. Less to spend.<br />Starting at $399</div>
+        </CarouselItem>
+        <CarouselItem className={'example tablet'}>
+          <div className={'title'}>Tablet</div>
+          <div className={'description'}>Just the right amount of everything</div>
+        </CarouselItem>
+        <CarouselItem className={'example airpods'}>
+          <div className={'title'}>But a Tablet or xPhone for college.<br />Get airPods.</div>
+        </CarouselItem>
+      </Carousel>
+    </div>
+  );
 }
 
 export default App;

--- a/frontend/src/components/aspect/Aspect.module.css
+++ b/frontend/src/components/aspect/Aspect.module.css
@@ -1,0 +1,12 @@
+.outer {
+  position: relative;
+  padding-top: 100%;
+}
+
+.inner {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}

--- a/frontend/src/components/aspect/index.tsx
+++ b/frontend/src/components/aspect/index.tsx
@@ -1,0 +1,43 @@
+import React, { useMemo } from 'react';
+import { useClassName } from '../../hooks';
+import classNames from './Aspect.module.css';
+
+export type AspectRatio = '16:9' | '4:3' | '1:1';
+
+export type AspectProps = {
+  ratio?: AspectRatio;
+  className?: string | undefined | null;
+  innerClassName?: string | undefined | null;
+}
+
+export const Aspect: React.FC<AspectProps & JSX.IntrinsicElements['div']> = ({
+  ratio = '16:9',
+  className,
+  innerClassName,
+  children,
+  ...props
+}) => {
+
+  const styles = useMemo(() => {
+    switch (ratio) {
+      case '16:9' :
+        return { paddingTop: 9 / 16 * 100 + '%' };
+      case '4:3' :
+        return { paddingTop: 3 / 4 * 100 + '%' };
+      default :
+        return {};
+    }
+  }, [ratio]);
+
+  return (
+    <div
+      {...props}
+      className={useClassName(classNames.outer, className, 'outer')}
+      style={styles}
+    >
+      <div className={useClassName(classNames.inner, innerClassName, 'inner')}>
+        {children}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/carousel/Carousel.module.css
+++ b/frontend/src/components/carousel/Carousel.module.css
@@ -1,0 +1,24 @@
+.container {
+  overflow: hidden;
+}
+
+.swiper {
+  height: 100%;
+  display: flex;
+  flex-flow: row nowrap;
+  align-content: stretch;
+  transform: translateX(0%);
+}
+
+.swiper > * {
+  flex: 1 0 100%;
+  display: flex;
+}
+
+.itemWrap {
+  background-color: red;
+}
+
+.itemWrap > .inner {
+  display: flex;
+}

--- a/frontend/src/components/carousel/Carousel.tsx
+++ b/frontend/src/components/carousel/Carousel.tsx
@@ -1,0 +1,175 @@
+import React, { createRef, ReactElement, useEffect, useMemo, useRef, useState } from 'react';
+import { useClassName } from '../../hooks';
+import { Aspect, AspectRatio } from '../aspect';
+import classes from './Carousel.module.css';
+import { CarouselContext } from './CarouselContext';
+import { CarouselIndicator } from './CarouselIndicator';
+import { CarouselItemProps } from './CarouselItem';
+
+export type CarouselProps = {
+  ratio?: AspectRatio;
+  autoplay?: boolean | number;
+  duration?: number;
+  className?: string | undefined | null;
+  children?: ReactElement<CarouselItemProps> | ReactElement<CarouselItemProps>[];
+}
+
+const getRelativeIndex = (index: number, size: number): number => {
+  if (size <= 0) return 0;
+  if (index >= 0 && index < size) {
+    return index;
+  }
+  const mod = index % size;
+  if (mod < 0) {
+    return mod + size;
+  }
+  return Math.abs(mod);
+};
+
+export const Carousel: React.FC<CarouselProps> = ({
+  ratio = '16:9',
+  autoplay = 3000,
+  duration = 500,
+  className,
+  children,
+}) => {
+  const swiperRef = createRef<HTMLDivElement>();
+  const switchingRef = useRef<false | number>(false);
+  const autoplayTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const timerTimestampRef = useRef<Date>(new Date());
+  const pauseLastRef = useRef<number>(0);
+  const pauseOnChangeRef = useRef(false);
+
+  const interval = useMemo(() => {
+    if (autoplay === true) return 3000;
+    else if (autoplay === false) return 0;
+    else if (autoplay <= 0) return 0;
+    else if (autoplay < 500) return 500; // 确保最少等待时间
+    return autoplay;
+  }, [autoplay]);
+
+  const items = children == null ? [] : (Array.isArray(children) ? children : [children]);
+  const total = items.length;
+  const [index, setIndex] = useState(0);
+  const [switching, setSwitching] = useState<false | number>(false);
+  const [isPause, setPause] = useState<boolean>(false);
+  const [pauseIndex, setPauseIndex] = useState(-1);
+  const isAutoplay = useMemo(() => interval > 0 && total > 1 && !isPause, [interval, total, isPause]);
+
+  const clearTimer = () => {
+    if (autoplayTimerRef.current != null) {
+      clearTimeout(autoplayTimerRef.current);
+    }
+  };
+
+  const startTimer = (nextIndex: number, ms?: number) => {
+    if (!isAutoplay) return;
+    clearTimer();
+    timerTimestampRef.current = new Date();
+    autoplayTimerRef.current = setTimeout(() => {
+      changeIndex(nextIndex);
+    }, ms || interval);
+  };
+
+  useEffect(() => {
+    if (isAutoplay) {
+      startTimer(index + 1);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isPause) {
+      clearTimer();
+    } else {
+      startTimer(index + 1, pauseLastRef.current);
+    }
+  }, [isPause]);
+
+  const onTrackTransitionEnd = () => {
+    if (switchingRef.current !== false) {
+      if (!pauseOnChangeRef.current) {
+        startTimer(switchingRef.current + 1);
+      }
+
+      switchingRef.current = false;
+      setSwitching(switchingRef.current);
+    }
+  };
+
+  useEffect(() => {
+    if (swiperRef.current != null) {
+      swiperRef.current.addEventListener('transitionend', onTrackTransitionEnd);
+    }
+  }, [swiperRef.current]);
+
+  const changeIndex = (idx: number) => {
+    clearTimer();
+    const nextIndex = getRelativeIndex(idx, total)
+    switchingRef.current = nextIndex;
+    setSwitching(switchingRef.current);
+    setIndex(nextIndex);
+    if (isPause) {
+      pauseOnChangeRef.current = true;
+      pauseLastRef.current = interval;
+      setPauseIndex(nextIndex);
+    }
+  };
+
+  const swiperStyle = {
+    transform : `translateX(-${index * 100}%)`,
+    transition: `transform ${duration}ms`,
+  };
+
+  const pause = () => {
+    if (isAutoplay) {
+      const date = new Date();
+      let last = interval - (date.valueOf() - timerTimestampRef.current.valueOf());
+      if (last <= 0) {
+        last = 0;
+      }
+      pauseLastRef.current = last;
+      setPause(true);
+      setPauseIndex(index);
+    }
+  };
+
+  const resume = () => {
+    setPause(false);
+    pauseOnChangeRef.current = false;
+  };
+
+  return (
+    <CarouselContext.Provider
+      value={{
+        ratio,
+        current: index,
+        total,
+        interval,
+        duration,
+        changeIndex,
+        switching,
+        isPause,
+        pauseIndex,
+        pause,
+        resume,
+      }}
+    >
+      <Aspect
+        ratio={ratio}
+        className={useClassName(classes.container, className)}
+        onMouseEnter={() => pause()}
+        onMouseLeave={() => resume()}
+      >
+        <div
+          ref={swiperRef}
+          className={useClassName(classes.swiper, 'carousel-swiper')}
+          style={swiperStyle}
+        >
+          {items}
+        </div>
+        <CarouselIndicator total={total}/>
+      </Aspect>
+    </CarouselContext.Provider>
+  );
+};

--- a/frontend/src/components/carousel/CarouselContext.tsx
+++ b/frontend/src/components/carousel/CarouselContext.tsx
@@ -1,0 +1,32 @@
+import { createContext, useContext } from 'react';
+import { AspectRatio } from '../aspect';
+
+export type CarouselContextType = {
+  ratio: AspectRatio;
+  current: number;
+  total: number;
+  interval: number;
+  duration: number;
+  changeIndex: (index: number) => void;
+  switching: false | number;
+  isPause: boolean;
+  pauseIndex: number;
+  pause: () => void;
+  resume: () => void;
+}
+
+export const CarouselContext = createContext<CarouselContextType>({
+  ratio      : '16:9',
+  current    : 0,
+  total      : 0,
+  interval   : 3000,
+  duration   : 500,
+  changeIndex: () => undefined,
+  switching  : false,
+  isPause    : false,
+  pauseIndex : -1,
+  pause      : () => undefined,
+  resume     : () => undefined,
+});
+
+export const useCarouselContext = () => useContext<CarouselContextType>(CarouselContext);

--- a/frontend/src/components/carousel/CarouselIndicator.module.css
+++ b/frontend/src/components/carousel/CarouselIndicator.module.css
@@ -1,0 +1,26 @@
+.indicator {
+  position: absolute;
+  bottom: 5%;
+  width: auto;
+  left: 50%;
+  transform: translateX(-50%);
+
+  display: flex;
+  gap: 0.25em;
+}
+
+.indicatorBar {
+  height: 4px;
+  width: 36px;
+  border-radius: 2px;
+  background-color: white;
+  overflow: hidden;
+}
+
+.indicatorBarProgress {
+  width: 100%;
+  height: 100%;
+  margin-left: auto;
+  background-color: #ccc;
+  cursor: pointer;
+}

--- a/frontend/src/components/carousel/CarouselIndicator.tsx
+++ b/frontend/src/components/carousel/CarouselIndicator.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useClassName } from '../../hooks';
+import { useCarouselContext } from './CarouselContext';
+import classes from './CarouselIndicator.module.css';
+
+export type CarouselIndicatorProps = {
+  total?: number
+}
+
+export const CarouselIndicator: React.FC<CarouselIndicatorProps> = ({ total = 0 }) => {
+  return (
+    <div className={useClassName(classes.indicator, 'carousel-indicator')}>
+      {new Array(total).fill(null).map((_, i) => {
+        return <CarouselIndicatorBar key={i} index={i}/>;
+      })}
+    </div>
+  );
+};
+
+type CarouselIndicatorBarProps = {
+  index: number,
+};
+
+const CarouselIndicatorBar: React.FC<CarouselIndicatorBarProps> = ({ index }) => {
+  const tickerRef = useRef<NodeJS.Timer | null>(null);
+  const tickCountRef = useRef<number>(0);
+
+  const tickStep = 1000 / 60;
+
+  const [tickCount, setTickCount] = useState(0);
+  const { current, interval, duration, total, isPause, pauseIndex, changeIndex } = useCarouselContext();
+  const active = useMemo(() => current === index, [current, index]);
+
+  const clearTicker = () => {
+    if (tickerRef.current != null) {
+      clearInterval(tickerRef.current);
+    }
+  };
+
+  const startTicker = (isContinue = false) => {
+    clearTicker();
+    if (active && interval > 0 && total > 1) {
+      if (!isContinue) {
+        tickCountRef.current = 0;
+        setTickCount(tickCountRef.current);
+      }
+      tickerRef.current = setInterval(() => {
+        tickCountRef.current += tickStep;
+        setTickCount(tickCountRef.current);
+      }, tickStep);
+    }
+  };
+
+  useEffect(() => {
+    if (current === index) {
+      if (isPause) {
+        clearTicker();
+      } else {
+        startTicker(pauseIndex === index);
+      }
+    } else {
+      clearTicker();
+      tickCountRef.current = 0;
+      setTickCount(0);
+    }
+  }, [current, index, pauseIndex, isPause]);
+
+  const width = active ? `${(1 - tickCount / (interval + duration)) * 100}%` : '100%';
+
+  return (
+    <div className={useClassName(classes.indicatorBar, 'carousel-indicator-bar')}>
+      <div
+        className={useClassName(classes.indicatorBarProgress, 'carousel-indicator-bar-progress')}
+        style={{ width }}
+        onClick={() => !active && changeIndex(index)}
+      />
+    </div>
+  );
+};

--- a/frontend/src/components/carousel/CarouselItem.module.css
+++ b/frontend/src/components/carousel/CarouselItem.module.css
@@ -1,0 +1,8 @@
+.item {
+  height: 100%;
+  width: 100%;
+  /*display: flex;*/
+  /*align-content: center;*/
+  /*justify-content: center;*/
+  /*align-items: center;*/
+}

--- a/frontend/src/components/carousel/CarouselItem.tsx
+++ b/frontend/src/components/carousel/CarouselItem.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useClassName } from '../../hooks';
+import { Aspect } from '../aspect';
+import { useCarouselContext } from './CarouselContext';
+import classes from './CarouselItem.module.css';
+
+export type CarouselItemProps = {
+  className?: string | undefined | null;
+}
+
+export const CarouselItem: React.FC<CarouselItemProps> = ({ className, children }) => {
+  const { ratio } = useCarouselContext();
+  return (
+    <Aspect ratio={ratio}>
+      <div className={useClassName(classes.item, 'carousel-item', className)}>
+        {children}
+      </div>
+    </Aspect>
+  );
+};

--- a/frontend/src/components/carousel/index.tsx
+++ b/frontend/src/components/carousel/index.tsx
@@ -1,0 +1,2 @@
+export * from './Carousel';
+export * from './CarouselItem';

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useClassName';

--- a/frontend/src/hooks/useClassName.ts
+++ b/frontend/src/hooks/useClassName.ts
@@ -1,0 +1,11 @@
+import { useMemo } from 'react';
+
+export const useClassName = (...classNames: (string | null | undefined)[]): string | undefined => {
+  return useMemo(() => {
+    const cls = classNames.filter(it => it != null && it).join(' ');
+    if (cls.trim() === '') {
+      return undefined;
+    }
+    return cls;
+  }, [classNames]);
+};


### PR DESCRIPTION
Carousel 效果已实现，组件样式使用 css modules，额外特性：

1. 允许通过 `ratio` 指定 Carousel 呈现比例，目前支持值：`16:9` （默认）`4:3` `1:1`，增加组件 Aspect 以实现；
2. Carousel 所在容器宽度自适应；
3. 添加 useClassName Hook；
4. Carousel 支持 mouseenter 的暂停效果，以及通过 CarouselIndicatorBar 点击切换。

Carousel 初始化属性说明：

- `ratio` 指定呈现比例，默认 `16:9`
- `autoplay` 指定自动轮播的间隔时间，取值允许 `false|number`，`false` 表示不自动轮播，任意数值，表示轮播的时间间隔，单位 ms，最小值限定在 500，默认不指定时为 3000
- `duration` 轮播切换的持续时间，任意数值，单位 ms，默认为 500

虽然使用 css modules，但每个相关节点，考虑后续开发者的样式控制，已添加相关的公共 className，以便于后期扩展。示例代码本身即通过公共 className 来扩展。


