### PR TITLE
feat: Implement Carousel components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules/
 
+coverage/

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,4 @@
+singleQuote: true
+printWidth: 80
+trailingComma: 'none'
+arrowParens: 'avoid'

--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+    presets: [
+        [
+            "@babel/preset-env",
+            {
+                targets: {
+                    node: "current"
+                }
+            }
+        ],
+        "@babel/preset-typescript",
+        '@babel/preset-react'
+    ]
+}

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,12 @@
+const config = {
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'md'],
+  moduleNameMapper: {
+    "\\.(css|scss)$": "identity-obj-proxy"
+  },
+  collectCoverageFrom: [
+    'src/components/**/*.{ts,tsx}',
+    '!src/tests/**'
+  ]
+};
+
+module.exports = config;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,9 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@babel/preset-env": "^7.20.2",
+    "@babel/preset-react": "^7.18.6",
+    "@babel/preset-typescript": "^7.18.6",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
@@ -14,14 +17,17 @@
     "@types/node": "^16.18.3",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.8",
+    "identity-obj-proxy": "^3.0.0",
     "react-scripts": "^5.0.1",
+    "sass": "^1.57.1",
     "typescript": "^4.8.4"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "coverage": "jest --coverage"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,4 +1,6 @@
 .App {
+  width: 100vw;
+  height: 100vh;
   text-align: center;
   position: relative;
 }

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  const { getByText } = render(<App />);
-  const linkElement = getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,40 @@
 import './App.css';
+import Carousel from './components/Carousel';
+import CarouselCard from './views/CarouselCard';
+import iphone from './assets/iphone.png';
+import tablet from './assets/tablet.png';
+import airpods from './assets/airpods.png';
 
 function App() {
-  return <div className='App'>{/* write your component here */}</div>;
+  return (
+    <div className="App">
+      <Carousel autoplay>
+        <CarouselCard backgroundColor="#111111" backgroundImage={iphone}>
+          <div style={{ color: '#fff' }}>
+            <h1 style={{ fontSize: 50 }}>xPhone</h1>
+            <span style={{ fontSize: 30 }}>
+              Lots to love. Less to spend.
+              <br />
+              Starting at $399.
+            </span>
+          </div>
+        </CarouselCard>
+        <CarouselCard backgroundColor="#FAFAFA" backgroundImage={tablet}>
+          <h1 style={{ fontSize: 50 }}>Tablet</h1>
+          <span style={{ fontSize: 30, fontWeight: 500 }}>
+            Just the right amount of everything.
+          </span>
+        </CarouselCard>
+        <CarouselCard backgroundColor="#F1F1F3" backgroundImage={airpods}>
+          <h1 style={{ fontSize: 60 }}>
+            Buy a Tablet or xPhone for college.
+            <br />
+            Get arPods
+          </h1>
+        </CarouselCard>
+      </Carousel>
+    </div>
+  );
 }
 
 export default App;

--- a/frontend/src/components/Carousel/Carousel.tsx
+++ b/frontend/src/components/Carousel/Carousel.tsx
@@ -1,0 +1,140 @@
+import React, {
+  forwardRef,
+  PropsWithChildren,
+  useCallback,
+  useRef,
+  useState
+} from 'react';
+import { useCarousel } from './hooks/useCarousel';
+import styles from './styles/Carousel.module.scss';
+import { classnames, createIncArray } from '../../utils';
+
+export interface CarouselProps {
+  autoplay?: boolean;
+  duration?: number;
+  speed?: number;
+  beforeChange?: (from: number, to: number) => void;
+  afterChange?: (current: number) => void;
+}
+
+export interface CarouselRef {
+  activeIndex: number;
+  goTo: (index: number) => void;
+  goNext: () => void;
+  goPrev: () => void;
+  stop: () => void;
+  start: () => void;
+  inner: any;
+}
+
+const Carousel = forwardRef<CarouselRef, PropsWithChildren<CarouselProps>>(
+  (
+    {
+      autoplay = true,
+      duration = 3000,
+      speed = 1000,
+      children,
+      beforeChange,
+      afterChange
+    },
+    ref
+  ) => {
+    const slidersCount = React.Children.count(children);
+
+    // Get all indexes of child nodes by its length
+    const slidersIndexes = createIncArray(slidersCount);
+
+    const [sliderWidth, setSliderWidth] = useState(0);
+
+    const { activeIndex, trackStyle, slideTo, startPlay, pausePlay } =
+      useCarousel({
+        autoplay,
+        duration,
+        speed,
+        slidersCount,
+        sliderWidth,
+        beforeChange,
+        afterChange
+      });
+
+    const sliderRef = useRef<HTMLDivElement>();
+
+    const inner = useRef({
+      onWindowResized: () => {
+        if (sliderRef.current) {
+          setSliderWidth(sliderRef.current.clientWidth);
+        }
+      }
+    });
+
+    /**
+     * This is done to facilitate jest testing.
+     * Because jest.spyOn can only tracks calls to object[methodName], so we need
+     * a wrapper and execute target function in it.
+     */
+    const handleWindowResized = () => inner.current.onWindowResized();
+
+    const containerRefHandler = useCallback(
+      (node: HTMLDivElement | null) => {
+        if (node) {
+          node.style.setProperty('--indicator-anim-duration', duration + 'ms');
+          setSliderWidth(node.scrollWidth);
+          sliderRef.current = node;
+
+          /**
+           * When the screen size changes, adjust the value of translate in CSS to make
+           * the slider adapt to the new screen size.
+           */
+          window.addEventListener('resize', handleWindowResized);
+        } else {
+          window.removeEventListener('resize', handleWindowResized);
+        }
+      },
+      [duration]
+    );
+
+    React.useImperativeHandle(
+      ref,
+      () => ({
+        activeIndex,
+        goTo: slideTo,
+        goNext: () => slideTo(activeIndex + 1),
+        goPrev: () => slideTo(activeIndex - 1),
+        stop: pausePlay,
+        start: startPlay,
+        inner: inner.current
+      }),
+      [activeIndex, inner, pausePlay, slideTo, startPlay]
+    );
+
+    return (
+      <div className={styles.container} ref={containerRefHandler}>
+        <div className={styles.track} style={trackStyle}>
+          {React.Children.map(children, (child, childIndex) => (
+            <div
+              className={classnames(styles.slider, {
+                [styles['slider-active']]: childIndex === activeIndex
+              })}
+            >
+              {child}
+            </div>
+          ))}
+        </div>
+        <ul className={styles.indicators}>
+          {slidersIndexes.map(currentIndex => (
+            <li key={currentIndex} onClick={() => slideTo(currentIndex)}>
+              <div
+                className={classnames(styles.indicator, {
+                  [styles[`is-active${autoplay ? '-anim' : ''}`]]:
+                    currentIndex === activeIndex
+                })}
+              ></div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  }
+);
+
+export default Carousel;

--- a/frontend/src/components/Carousel/__tests__/Carousel.test.tsx
+++ b/frontend/src/components/Carousel/__tests__/Carousel.test.tsx
@@ -1,8 +1,13 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import React from 'react';
 import { render } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 import Carousel, { CarouselRef } from '../Carousel';
 import { waitFakeTimer, windowResize } from '../../../tests/utils';
+import '@testing-library/jest-dom/extend-expect';
 
 describe('Carousel', () => {
   beforeEach(() => {

--- a/frontend/src/components/Carousel/__tests__/Carousel.test.tsx
+++ b/frontend/src/components/Carousel/__tests__/Carousel.test.tsx
@@ -1,0 +1,199 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+import Carousel, { CarouselRef } from '../Carousel';
+import { waitFakeTimer, windowResize } from '../../../tests/utils';
+
+describe('Carousel', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should render Carousel component', () => {
+    const { container } = render(
+      <Carousel>
+        <div />
+      </Carousel>
+    );
+    expect(container).toBeInTheDocument();
+  });
+
+  it('should render the correct number of indicators', () => {
+    const { container, rerender } = render(<Carousel />);
+    expect(container.querySelectorAll('.indicator').length).toBe(0);
+
+    // Update children
+    rerender(
+      <Carousel>
+        <div>1</div>
+        <div>2</div>
+        <div>3</div>
+      </Carousel>
+    );
+    expect(container.querySelectorAll('.indicator').length).toBe(3);
+  });
+
+  it('should active slider when children change', () => {
+    const { rerender, container } = render(<Carousel />);
+    expect(container.querySelector('.slider-active')).toBeFalsy();
+
+    // Update children
+    rerender(
+      <Carousel>
+        <div />
+      </Carousel>
+    );
+    expect(container.querySelector('.slider-active')).toBeTruthy();
+  });
+
+  it('should have goTo, goPrev and goNext function and work normally', async () => {
+    const ref = React.createRef<CarouselRef>();
+    render(
+      <Carousel ref={ref}>
+        <div>1</div>
+        <div>2</div>
+        <div>3</div>
+      </Carousel>
+    );
+
+    const { goTo, goPrev, goNext } = ref.current || {};
+
+    expect(typeof goTo).toBe('function');
+    expect(typeof goPrev).toBe('function');
+    expect(typeof goNext).toBe('function');
+
+    act(() => {
+      ref.current?.goTo(2);
+    });
+    await waitFakeTimer();
+    expect(ref.current?.activeIndex).toBe(2);
+    act(() => {
+      ref.current?.goPrev();
+    });
+    await waitFakeTimer();
+    expect(ref.current?.activeIndex).toBe(1);
+    act(() => {
+      ref.current?.goNext();
+    });
+    await waitFakeTimer();
+    expect(ref.current?.activeIndex).toBe(2);
+  });
+
+  it('should have start and stop function and work normally', async () => {
+    const ref = React.createRef<CarouselRef>();
+    render(
+      <Carousel ref={ref}>
+        <div>1</div>
+        <div>2</div>
+        <div>3</div>
+      </Carousel>
+    );
+
+    const { start, stop } = ref.current || {};
+
+    expect(typeof start).toBe('function');
+    expect(typeof stop).toBe('function');
+
+    expect(ref.current?.activeIndex).toBe(0);
+
+    // wait for animation to be finished
+    await waitFakeTimer();
+    await waitFakeTimer();
+    expect(ref.current?.activeIndex).toBe(1);
+
+    ref.current?.stop();
+    await waitFakeTimer();
+    expect(ref.current?.activeIndex).toBe(1);
+
+    ref.current?.start();
+    expect(ref.current?.activeIndex).toBe(1);
+
+    // wait for animation to be finished
+    await waitFakeTimer();
+    await waitFakeTimer();
+    expect(ref.current?.activeIndex).toBe(2);
+  });
+
+  it('should trigger onWindowResized after window resize', async () => {
+    const ref = React.createRef<CarouselRef>();
+    render(
+      <Carousel ref={ref}>
+        <div>1</div>
+        <div>2</div>
+        <div>3</div>
+      </Carousel>
+    );
+    const spy = jest.spyOn(ref.current?.inner, 'onWindowResized');
+    expect(spy).not.toHaveBeenCalled();
+    windowResize(1000, window.innerHeight);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should cancel resize listener when unmount', () => {
+    const windowSpy = jest.spyOn(window, 'removeEventListener');
+    const { unmount } = render(<Carousel />);
+
+    unmount();
+    expect(windowSpy).toHaveBeenCalled();
+  });
+
+  it('should active corresponding slider and indicator when the active index changes', async () => {
+    const ref = React.createRef<CarouselRef>();
+
+    // autoplay
+    const { container, rerender } = render(
+      <Carousel ref={ref}>
+        <div>1</div>
+        <div>2</div>
+        <div>3</div>
+      </Carousel>
+    );
+
+    expect(container.querySelectorAll('.slider')[0]).toHaveClass(
+      'slider-active'
+    );
+    expect(container.querySelectorAll('.indicator')[0]).toHaveClass(
+      'is-active-anim'
+    );
+
+    act(() => ref.current?.goTo(1));
+    await waitFakeTimer();
+    expect(container.querySelectorAll('.slider')[1]).toHaveClass(
+      'slider-active'
+    );
+    expect(container.querySelectorAll('.indicator')[1]).toHaveClass(
+      'is-active-anim'
+    );
+
+    // not autoplay
+    rerender(
+      <Carousel autoplay={false} ref={ref}>
+        <div>1</div>
+        <div>2</div>
+        <div>3</div>
+      </Carousel>
+    );
+
+    act(() => ref.current?.goTo(0));
+    await waitFakeTimer();
+    expect(container.querySelectorAll('.slider')[0]).toHaveClass(
+      'slider-active'
+    );
+    expect(container.querySelectorAll('.indicator')[0]).toHaveClass(
+      'is-active'
+    );
+
+    act(() => ref.current?.goTo(1));
+    await waitFakeTimer();
+    expect(container.querySelectorAll('.slider')[1]).toHaveClass(
+      'slider-active'
+    );
+    expect(container.querySelectorAll('.indicator')[1]).toHaveClass(
+      'is-active'
+    );
+  });
+});

--- a/frontend/src/components/Carousel/__tests__/useCarousel.test.ts
+++ b/frontend/src/components/Carousel/__tests__/useCarousel.test.ts
@@ -1,7 +1,12 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { renderHook } from '@testing-library/react';
 import { useCarousel, UseCarouselProps } from '../hooks/useCarousel';
 import { waitFakeTimer } from '../../../tests/utils';
 import { act } from 'react-dom/test-utils';
+import '@testing-library/jest-dom/extend-expect';
 
 const setupHook = (initialProps: UseCarouselProps) =>
   renderHook(props => useCarousel(props), {

--- a/frontend/src/components/Carousel/__tests__/useCarousel.test.ts
+++ b/frontend/src/components/Carousel/__tests__/useCarousel.test.ts
@@ -1,0 +1,152 @@
+import { renderHook } from '@testing-library/react';
+import { useCarousel, UseCarouselProps } from '../hooks/useCarousel';
+import { waitFakeTimer } from '../../../tests/utils';
+import { act } from 'react-dom/test-utils';
+
+const setupHook = (initialProps: UseCarouselProps) =>
+  renderHook(props => useCarousel(props), {
+    initialProps
+  });
+
+describe('useCarousel', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should have a return value after render', () => {
+    const initialProps = {
+      slidersCount: 2,
+      sliderWidth: 100
+    };
+
+    const { result } = setupHook(initialProps);
+
+    const {
+      activeIndex,
+      isAnimating,
+      trackStyle,
+      slideTo,
+      pausePlay,
+      startPlay
+    } = result.current;
+
+    expect(typeof activeIndex).toBe('number');
+    expect(typeof isAnimating).toBe('boolean');
+    expect(typeof trackStyle).toBe('object');
+    expect(typeof slideTo).toBe('function');
+    expect(typeof pausePlay).toBe('function');
+    expect(typeof startPlay).toBe('function');
+  });
+
+  it('should slide to the next slider at intervals when autoplay', async () => {
+    const initialProps = {
+      slidersCount: 2,
+      sliderWidth: 100,
+      duration: 3000,
+      speed: 1000
+    };
+
+    const { result } = setupHook(initialProps);
+
+    expect(result.current.activeIndex).toBe(0);
+    expect(result.current.isAnimating).toBe(false);
+    expect(result.current.trackStyle).toEqual({
+      width: '200px',
+      transform: 'translateX(0px)',
+      transition: ''
+    });
+
+    await waitFakeTimer(3000, 1);
+    expect(result.current.activeIndex).toBe(1);
+    expect(result.current.isAnimating).toBe(true);
+    expect(result.current.trackStyle).toEqual({
+      width: '200px',
+      transform: 'translateX(-100px)',
+      transition: 'transform 1000ms ease-in-out'
+    });
+
+    await waitFakeTimer(1000, 1);
+    expect(result.current.isAnimating).toBe(false);
+    expect(result.current.trackStyle).toEqual({
+      width: '200px',
+      transform: 'translateX(-100px)',
+      transition: ''
+    });
+
+    await waitFakeTimer(2000, 1);
+    expect(result.current.activeIndex).toBe(0);
+    expect(result.current.isAnimating).toBe(true);
+    expect(result.current.trackStyle).toEqual({
+      width: '200px',
+      transform: 'translateX(0px)',
+      transition: 'transform 1000ms ease-in-out'
+    });
+
+    await waitFakeTimer(1000, 1);
+    expect(result.current.isAnimating).toBe(false);
+    expect(result.current.trackStyle).toEqual({
+      width: '200px',
+      transform: 'translateX(0px)',
+      transition: ''
+    });
+  });
+
+  it('should change trackStyle every time the dependent props change', async () => {
+    const initialProps = {
+      slidersCount: 2,
+      sliderWidth: 100,
+      duration: 3000,
+      speed: 500,
+      autoplay: false
+    };
+
+    const { result, rerender } = setupHook(initialProps);
+
+    expect(result.current.trackStyle).toEqual({
+      width: '200px',
+      transform: 'translateX(0px)',
+      transition: ''
+    });
+
+    // sliderWidth changed
+    initialProps.sliderWidth = 500;
+    rerender(initialProps);
+    expect(result.current.trackStyle).toEqual({
+      width: '1000px',
+      transform: 'translateX(0px)',
+      transition: ''
+    });
+
+    // slidersCount changed
+    initialProps.slidersCount = 3;
+    rerender(initialProps);
+    expect(result.current.trackStyle).toEqual({
+      width: '1500px',
+      transform: 'translateX(0px)',
+      transition: ''
+    });
+
+    // speed changed
+    act(() => result.current.slideTo(1));
+    await waitFakeTimer(100, 1);
+    expect(result.current.trackStyle).toEqual({
+      width: '1500px',
+      transform: 'translateX(-500px)',
+      transition: 'transform 500ms ease-in-out'
+    });
+
+    initialProps.speed = 1000;
+    rerender(initialProps);
+    act(() => result.current.slideTo(1));
+    await waitFakeTimer(100, 1);
+    expect(result.current.trackStyle).toEqual({
+      width: '1500px',
+      transform: 'translateX(-500px)',
+      transition: 'transform 1000ms ease-in-out'
+    });
+  });
+});

--- a/frontend/src/components/Carousel/hooks/useCarousel.ts
+++ b/frontend/src/components/Carousel/hooks/useCarousel.ts
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { CarouselProps } from '../Carousel';
+import { calcTrackStyle } from '../utils';
+
+export interface UseCarouselProps extends CarouselProps {
+  slidersCount: number;
+  sliderWidth: number;
+}
+
+export const useCarousel = ({
+  slidersCount,
+  sliderWidth,
+  duration = 3000,
+  autoplay = true,
+  speed = 1000,
+  beforeChange,
+  afterChange
+}: UseCarouselProps) => {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const [isAnimating, setIsAnimating] = useState(false);
+
+  const autoplayTimer = useRef<NodeJS.Timer | null>(null);
+  const animatingTimer = useRef<NodeJS.Timer | null>(null);
+
+  const trackStyle = useMemo(
+    () =>
+      calcTrackStyle({
+        activeIndex,
+        sliderWidth,
+        slidersCount,
+        isAnimating,
+        speed
+      }),
+    [activeIndex, isAnimating, sliderWidth, slidersCount, speed]
+  );
+
+  const translateItem = useCallback(
+    (index: number) => {
+      setActiveIndex(index >= slidersCount ? 0 : index);
+    },
+    [slidersCount, setActiveIndex]
+  );
+
+  const translateHandler = useCallback(
+    (index: number) => {
+      translateItem(index);
+
+      /**
+       * When the animation is playing, set the value of isAnimating to true,
+       * and set it to false after playing.
+       */
+      setIsAnimating(true);
+      beforeChange && beforeChange(activeIndex, index);
+
+      animatingTimer.current = setTimeout(() => {
+        setIsAnimating(false);
+        afterChange && afterChange(activeIndex);
+        animatingTimer.current = null;
+      }, speed);
+    },
+    [activeIndex, afterChange, beforeChange, speed, translateItem]
+  );
+
+  const pausePlay = () => {
+    if (autoplayTimer.current) {
+      clearInterval(autoplayTimer.current);
+      autoplayTimer.current = null;
+    }
+  };
+
+  const startPlay = useCallback(() => {
+    if (autoplayTimer.current) {
+      clearInterval(autoplayTimer.current);
+    }
+
+    if (autoplay) {
+      autoplayTimer.current = setInterval(() => {
+        translateHandler(activeIndex + 1);
+      }, duration);
+    }
+  }, [activeIndex, autoplay, duration, translateHandler]);
+
+  const slideTo = useCallback(
+    (index: number) => {
+      if (index === activeIndex || isAnimating) return;
+
+      // restart autoplay of translate animation
+      startPlay();
+
+      translateHandler(index);
+    },
+    [activeIndex, isAnimating, startPlay, translateHandler]
+  );
+
+  // initialize Carousel
+  useEffect(() => {
+    startPlay();
+  }, [startPlay]);
+
+  return {
+    activeIndex,
+    isAnimating,
+    trackStyle,
+    slideTo,
+    pausePlay,
+    startPlay
+  };
+};

--- a/frontend/src/components/Carousel/index.ts
+++ b/frontend/src/components/Carousel/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Carousel';
+export type { CarouselRef } from './Carousel';

--- a/frontend/src/components/Carousel/styles/Carousel.module.scss
+++ b/frontend/src/components/Carousel/styles/Carousel.module.scss
@@ -1,0 +1,84 @@
+.container {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  overflow: hidden;
+}
+
+.track {
+  flex: 1;
+  position: relative;
+  top: 0;
+  inset-inline-start: 0;
+  display: block;
+  display: flex;
+  overflow: hidden;
+  margin: 0;
+  padding: 0;
+}
+
+.slider {
+  height: 100%;
+  min-height: 1px;
+  pointer-events: none;
+
+  &.slider-active {
+    pointer-events: auto;
+  }
+}
+
+.indicators {
+  z-index: 15;
+  width: 100%;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  bottom: 30px;
+}
+
+.indicator {
+  z-index: 20;
+  width: 50px;
+  height: 3px;
+  padding: 12px 0;
+  margin: 0 6px;
+  background-clip: content-box;
+  background-color: #b0b0b0;
+  cursor: pointer;
+  overflow: hidden;
+
+  &:hover {
+    background-color: #fff;
+  }
+
+  &::after {
+    content: '';
+    width: 50px;
+    height: 3px;
+    display: block;
+    background-color: #fff;
+    transform: translateX(-50px);
+  }
+
+  &.is-active {
+    background-color: #fff;
+  }
+
+  &.is-active-anim::after {
+    animation: var(--indicator-anim-duration) linear indicatorAnim forwards;
+  }
+}
+
+@keyframes indicatorAnim {
+  from {
+    transform: translateX(-50px);
+  }
+  to {
+    transform: translateX(0);
+  }
+}

--- a/frontend/src/components/Carousel/utils/index.ts
+++ b/frontend/src/components/Carousel/utils/index.ts
@@ -1,0 +1,35 @@
+interface CalcTrackStyleProps {
+  activeIndex: number;
+  sliderWidth: number;
+  slidersCount: number;
+  isAnimating: boolean;
+  speed: number;
+}
+
+export interface TrackStyle {
+  width: string;
+  transform: string;
+  transition: string;
+}
+
+export const calcTrackStyle = ({
+  activeIndex,
+  sliderWidth,
+  slidersCount,
+  isAnimating,
+  speed
+}: CalcTrackStyleProps): TrackStyle => {
+  let transition = '';
+  if (isAnimating) {
+    transition = `transform ${speed}ms ease-in-out`;
+  }
+
+  const trackWidth = sliderWidth * slidersCount;
+  const translate = sliderWidth * activeIndex * -1;
+
+  return {
+    width: `${trackWidth}px`,
+    transform: `translateX(${translate}px)`,
+    transition
+  };
+};

--- a/frontend/src/tests/utils.ts
+++ b/frontend/src/tests/utils.ts
@@ -1,0 +1,29 @@
+import { act } from 'react-dom/test-utils';
+
+export function windowResize(x: number, y: number) {
+  window.innerWidth = x;
+  window.innerHeight = y;
+  window.dispatchEvent(new Event('resize'));
+}
+
+/**
+ * Copy from ant-design: https://github.com/ant-design/ant-design/blob/master/tests/utils.tsx#L77
+ * Wait for a time delay. Will wait `advanceTime * times` ms.
+ *
+ * @param advanceTime Default 1000
+ * @param times Default 20
+ */
+export async function waitFakeTimer(advanceTime = 1000, times = 20) {
+  for (let i = 0; i < times; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await act(async () => {
+      await Promise.resolve();
+
+      if (advanceTime > 0) {
+        jest.advanceTimersByTime(advanceTime);
+      } else {
+        jest.runAllTimers();
+      }
+    });
+  }
+}

--- a/frontend/src/utils/__tests__/classnames.test.ts
+++ b/frontend/src/utils/__tests__/classnames.test.ts
@@ -1,0 +1,33 @@
+import { classnames } from '..';
+
+describe('classnames', () => {
+  it('should combine the classes of all string type into a class string', () => {
+    const result = classnames('a', 'b', 'c');
+
+    expect(result).toBe('a b c');
+  });
+
+  it('should combine the keys of object only the key with the value of true in object', () => {
+    const classesObj = {
+      a: true,
+      b: false,
+      c: true
+    };
+
+    const result = classnames(classesObj);
+
+    expect(result).toBe('a c');
+  });
+
+  it('should correctly combine the class string when mixing object and string', () => {
+    const classesObj = {
+      a: true,
+      b: false,
+      c: true
+    };
+
+    const result = classnames('1', classesObj, '2', '3');
+
+    expect(result).toBe('1 a c 2 3');
+  });
+});

--- a/frontend/src/utils/__tests__/createIncArray.test.ts
+++ b/frontend/src/utils/__tests__/createIncArray.test.ts
@@ -1,0 +1,28 @@
+import { createIncArray } from '..';
+
+describe('createIncArray', () => {
+  it('should return empty array when the length is 0', () => {
+    const length = 0;
+
+    const incArr = createIncArray(length);
+
+    expect(incArr).toEqual([]);
+  });
+
+  it('should create an incremental array', () => {
+    const length = 5;
+
+    const incArr = createIncArray(length);
+
+    expect(incArr).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('should create an array incrementing from the starting number', () => {
+    const length = 5;
+    const start = 2;
+
+    const incArr = createIncArray(length, start);
+
+    expect(incArr).toEqual([2, 3, 4, 5, 6]);
+  });
+});

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,0 +1,28 @@
+export const createIncArray = (
+  length: number,
+  start: number = 0
+): Array<number> => {
+  return Array.from(Array(length), (v, k) => k + start);
+};
+
+export const classnames = (
+  ...args: (string | Record<string, boolean>)[]
+): string => {
+  const classes: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (typeof arg === 'string') {
+      classes.push(arg);
+    } else if (typeof arg === 'object') {
+      for (const key of Object.keys(arg)) {
+        if (arg[key]) {
+          classes.push(key);
+        }
+      }
+    }
+  }
+
+  return classes.join(' ');
+};

--- a/frontend/src/views/CarouselCard/CarouselCard.tsx
+++ b/frontend/src/views/CarouselCard/CarouselCard.tsx
@@ -1,0 +1,18 @@
+import { PropsWithChildren } from 'react';
+import styles from './styles/CarouselCard.module.scss';
+
+const CarouselCard: React.FC<
+  PropsWithChildren<{ backgroundColor: string; backgroundImage: string }>
+> = ({ backgroundColor, backgroundImage, children }) => (
+  <div
+    className={styles.container}
+    style={{
+      backgroundColor,
+      backgroundImage: `url(${backgroundImage})`
+    }}
+  >
+    {children}
+  </div>
+);
+
+export default CarouselCard;

--- a/frontend/src/views/CarouselCard/index.ts
+++ b/frontend/src/views/CarouselCard/index.ts
@@ -1,0 +1,1 @@
+export {default} from './CarouselCard'

--- a/frontend/src/views/CarouselCard/styles/CarouselCard.module.scss
+++ b/frontend/src/views/CarouselCard/styles/CarouselCard.module.scss
@@ -1,0 +1,10 @@
+.container {
+  width: 100vw;
+  height: 100%;
+  box-sizing: border-box;
+  padding: 100px 200px 0;
+  background-size: auto 50%;
+  background-repeat: no-repeat;
+  background-position: center 220px;
+  overflow: hidden;
+}


### PR DESCRIPTION
## 介绍

各位前辈好，我叫郑炜焜，是22届毕业的计算机本科生，目前是 0.5 到 1 年的工作经验，代码写得不好的地方还请各位前辈赐教

项目基于 TDD 的思想，在实现代码之前，通过先写单元测试描述的方式理清思路，并为主要逻辑都编写了单元测试代码，达到了一个相对比较高的测试覆盖率：
![image](https://user-images.githubusercontent.com/57286975/216950787-fd641593-c0c2-4094-aef5-0c3304f24c98.png)

在设计上，**将轮播图的逻辑和业务分开**，让 `Carousel` 组件只负责切换面板、处理动画的相关逻辑，放置于 `src/components` 目录下；每一个面板中要放什么则是另起炉灶，使用 `CarouselCard` 去定义文字、图片内容，以及如何展示（位置、大小等），放置于 `src/views` 目录下。



## Props

| 参数         | 说明                     | 类型                               | 默认值 |
| ------------ | ------------------------ | ---------------------------------- | ------ |
| autoplay     | 是否开启自动播放         | boolean                            | true   |
| duration     | 当前面板的展示时长 (ms)  | number                             | 3000   |
| speed        | 切换面板时的移动速度(ms) | number                             | 1000   |
| beforeChange | 面板切换前的回调         | (from: number, to: number) => void |        |
| afterChange  | 面板切换后的回调         | (current: number) => void          | -      |



## 方法

| 名称   | 说明                               |
| ------ | ---------------------------------- |
| goTo   | 切换到指定面板，接收一个参数 index |
| goNext | 切换到下一个面板                   |
| goPrev | 切换到上一个面板                   |
| start  | 开启面板自动切换                   |
| stop   | 停止面板自动切换                   |

